### PR TITLE
Clear m_PluginChildren to prevent stale entries.

### DIFF
--- a/src/diagnosebasic.cpp
+++ b/src/diagnosebasic.cpp
@@ -256,6 +256,7 @@ bool DiagnoseBasic::missingMasters() const
   }
 
   m_MissingMasters.clear();
+  m_PluginChildren.clear();
   // for each required master in each esp, test if it's in the list of enabled masters.
   for (const QString &esp : esps) {
     QString baseName = QFileInfo(esp).fileName();


### PR DESCRIPTION
This change clears m_PluginChildren before insertion to address the case where a deactivated plugin is listed in the 'Required By' section of the 'Missing Masters' notification menu, while the master is still missing.