### PR TITLE
Fix SSE check in invalidFontConfig

### DIFF
--- a/src/diagnosebasic.cpp
+++ b/src/diagnosebasic.cpp
@@ -284,7 +284,7 @@ bool DiagnoseBasic::alternateGame() const
 
 bool DiagnoseBasic::invalidFontConfig() const
 {
-  if ((m_MOInfo->managedGame()->gameName() != "Skyrim") && (m_MOInfo->managedGame()->gameName() != "SkyrimSE"))  {
+  if ((m_MOInfo->managedGame()->gameName() != "Skyrim") && (m_MOInfo->managedGame()->gameShortName() != "SkyrimSE"))  {
     // this check is only for skyrim
     return false;
   }


### PR DESCRIPTION
This fixes a small bug in invalidFontConfig to make it work with a Skyrim Special Edition instance. The full gameName is "Skyrim Special Edition", so I changed the check to use gameShortName.