### PR TITLE
Add fonts_cclub.swf to font config check

### DIFF
--- a/src/diagnosebasic.cpp
+++ b/src/diagnosebasic.cpp
@@ -291,7 +291,8 @@ bool DiagnoseBasic::invalidFontConfig() const
 
   // files from skyrim_interface.bsa
   static std::vector<QString> defaultFonts = boost::assign::list_of("interface\\fonts_console.swf")
-                                               ("interface\\fonts_en.swf");
+                                                                   ("interface\\fonts_en.swf")
+                                                                   ("interface\\fonts_cclub.swf");
 
   QString configPath = m_MOInfo->resolvePath("interface/fontconfig.txt");
   if (configPath.isEmpty()) {


### PR DESCRIPTION
Not sure how long ago this was added but this check incorrectly flags the default fonts_cclub.swf as invalid. At some point it was added to the SSE `Skyrim - Interface.bsa`.

I was able to replicate the issue by merely extracting the fontconfig.txt from the core BSA and placing it in a mod.